### PR TITLE
Disable widget control of units

### DIFF
--- a/common/springOverrides.lua
+++ b/common/springOverrides.lua
@@ -71,5 +71,19 @@ if Spring.Echo then
 		end
 	end
 
-	Spring.Echo = multiEcho
+        Spring.Echo = multiEcho
+end
+
+-- Disable widget issued unit orders
+if Spring.GiveOrderToUnit then
+    local function disabledOrder()
+        Spring.Echo("Widget issued unit order blocked")
+        return false
+    end
+
+    Spring.GiveOrder = disabledOrder
+    Spring.GiveOrderToUnit = disabledOrder
+    Spring.GiveOrderToUnitArray = disabledOrder
+    Spring.GiveOrderArrayToUnit = disabledOrder
+    Spring.GiveOrderArrayToUnitArray = disabledOrder
 end


### PR DESCRIPTION
## Summary
- prevent LuaUI widgets from issuing unit orders by patching the Spring API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68571051eb98832f88ea0b435ac3caf5