### PR TITLE
Limit widget order block to LuaUI

### DIFF
--- a/common/springOverrides.lua
+++ b/common/springOverrides.lua
@@ -75,7 +75,8 @@ if Spring.Echo then
 end
 
 -- Disable widget issued unit orders
-if Spring.GiveOrderToUnit then
+local environment = Script.GetName and Script.GetName()
+if environment == "LuaUI" and Spring.GiveOrderToUnit then
     local function disabledOrder()
         Spring.Echo("Widget issued unit order blocked")
         return false

--- a/modules/lava.lua
+++ b/modules/lava.lua
@@ -69,7 +69,7 @@ local tideRhythm = {}
 local function trimMapVersion(mapName)
 	-- Trims version from the end of the map name.
 	-- find last space before version (version is numbers with dots, possibly preceded by v or V)
-	local lastSpace = mapName:match'^.*()\ [vV]*[%d%.]+'
+    local lastSpace = mapName:match("^.*() [vV]*[%d%.]+")
 	if not lastSpace then return mapName end
 	return string.sub(mapName, 1, lastSpace - 1)
 end


### PR DESCRIPTION
## Summary
- block `Spring.GiveOrder*` only when running in LuaUI
- fix invalid escape sequence warning in `modules/lava.lua`

## Testing
- `luacheck common/springOverrides.lua modules/lava.lua --no-color`
- `luacheck . --no-color`

